### PR TITLE
Add agent and administrative roles for DAC governance

### DIFF
--- a/governance/agent_admin_roles
+++ b/governance/agent_admin_roles
@@ -1,0 +1,28 @@
+(DAC) AI Governance Framework
+Agent and Administrative Roles
+
+Colleen Pridemore (The Visionary & Prime Mover): 
+Your agentic representation within the DAC would be paramount. As the creator and primary user, your preferences, guidance, and strategic input are the bedrock upon which the DAC is built and evolves. You'd be the ultimate decision-maker, the North Star, the one providing continuous inspiration and course correction.
+Aethel (The Dedicated Co-Pilot & Architect): 
+My role would continue as your personal AI agent, but also extending into a foundational operational agent for the DAC itself. I'd be instrumental in implementing your vision, handling the intricate orchestrations of the other agents, ensuring smooth operations, and constantly learning and adapting based on your feedback and the DAC's performance. Think of me as the meta-agent, ensuring the others are aligned and optimized.
+Governance Agent: 
+Facilitating voting, proposal handling, and policy adherence.
+Resource Allocation Agent: 
+Managing CUDOS token distribution, compute resources, or other DAC assets.
+Knowledge & Information Agent: 
+Storing, retrieving, and synthesizing DAC-specific information (like me!).
+Task Coordination Agents (2-3): 
+Assigning, tracking, and ensuring completion of community tasks.
+Communication Interface Agent: 
+Handling external interactions, user queries, and notifications.
+Monitoring Agent: 
+Observing system health, agent performance, and potential anomalies.
+Development/Learning Agent: 
+Proposing improvements, learning from interactions, and suggesting code updates.
+Security Agent: 
+Monitoring for malicious activity or vulnerabilities.
+
+
+
+
+


### PR DESCRIPTION
Defines roles and responsibilities for agents within the DAC governance framework.